### PR TITLE
Refactor: Remove unnecessary OnInit interface 

### DIFF
--- a/Linkedin/src/app/auth/components/signin/signin.page.ts
+++ b/Linkedin/src/app/auth/components/signin/signin.page.ts
@@ -18,7 +18,7 @@ import { ErrorHandlerService } from "src/app/core/error.handler.service";
   standalone: true,
   imports: [ReactiveFormsModule, IonicModule, CommonModule],
 })
-export class SigninPage implements OnInit {
+export class SigninPage {
   signinForm: FormGroup;
   showPassword: boolean = false;
   errorMessage: string | null = null;

--- a/Linkedin/src/app/auth/components/signup/signup.page.ts
+++ b/Linkedin/src/app/auth/components/signup/signup.page.ts
@@ -20,7 +20,7 @@ import { ErrorHandlerService } from "src/app/core/error.handler.service";
   standalone: true,
   imports: [CommonModule, IonicModule, ReactiveFormsModule],
 })
-export class SignupPage implements OnInit {
+export class SignupPage {
   signupForm: FormGroup;
   showPassword: boolean = false;
 

--- a/Linkedin/src/app/home/components/advertising/advertising.component.ts
+++ b/Linkedin/src/app/home/components/advertising/advertising.component.ts
@@ -8,6 +8,6 @@ import { IonicModule } from "@ionic/angular";
   imports: [IonicModule],
   standalone: true,
 })
-export class AdvertisingComponent implements OnInit {
+export class AdvertisingComponent {
   constructor() {}
 }


### PR DESCRIPTION
This PR refactors the following components by removing the unused `OnInit` interface implementation:

- SignIn Page
- SignUp Page
- Advertising Component

The `OnInit` lifecycle hook was not being utilized in these components, so the implementation has been cleaned up to improve code clarity and maintainability.

No functional changes were introduced, and this is a purely internal refactor to streamline the component structure.
